### PR TITLE
Feature/Hint Opacity

### DIFF
--- a/ScreenHint/HintWindowController.swift
+++ b/ScreenHint/HintWindowController.swift
@@ -62,6 +62,11 @@ class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate,
         copyTextItem.image = NSImage(systemSymbolName: "text.viewfinder", accessibilityDescription: nil)
         copyTextItem.keyEquivalentModifierMask = [.command]
         copyTextItem.target = self
+      
+        let opacityItem = menu.addItem(withTitle: "Set Opacity", action: #selector(self.menuOpacityHandler(_:)), keyEquivalent: "O")
+        opacityItem.image = NSImage(systemSymbolName: "drop.halffull", accessibilityDescription: nil)
+        opacityItem.keyEquivalentModifierMask = [.command]
+        opacityItem.target = self
         
         menu.addItem(NSMenuItem.separator())
         
@@ -119,6 +124,10 @@ class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate,
     
     @objc func menuCopyHandler(_ sender: AnyObject?) {
         self.shouldCopy()
+    }
+  
+    @objc func menuOpacityHandler(_ sender: AnyObject?) {
+        self.hintWindow.showOpacitySlider()
     }
                                               
     @objc func borderlessModeHandler(_ sender: AnyObject?) {

--- a/ScreenHint/HintWindowController.swift
+++ b/ScreenHint/HintWindowController.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import Vision
 import UniformTypeIdentifiers
 
-class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate, NSMenuDelegate {
+class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate, BorderDelegate, NSMenuDelegate {
     
     var hintWindow: HintWindow
     var screenshot: CGImage?
@@ -44,6 +44,7 @@ class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate,
         
         window.delegate = self
         window.copyDelegate = self
+        window.borderDelegate = self
         
         // Initialize the menu
         // TODO: put this in its own method
@@ -200,6 +201,10 @@ class HintWindowController:  NSWindowController, NSWindowDelegate, CopyDelegate,
         self.isBorderless = isBorderless
         self.hintWindow.setBorderlessMode(isBorderless)
         self.borderlessModeMenuItem?.state = self.isBorderless ? .on : .off
+    }
+  
+    func shouldSetBorder() {
+        shouldSetBorderlessMode(!isBorderless)
     }
     
     /**


### PR DESCRIPTION
Created a Hint menu entry "Set Opacity" which shows up a slider where you can slide to change opacity of the Hint. Minimum opacity is capped at 0.2.

Also added keyboard shortcuts for settings opacity and fixed existing shortcuts.